### PR TITLE
A27.1 : Implement PolyFill assignment

### DIFF
--- a/GrayBMP.cs
+++ b/GrayBMP.cs
@@ -113,7 +113,7 @@ class GrayBMP {
       if (x2 < x1) (x2, x1) = (x1, x2);
       byte bGray = (byte)gray;
       unsafe {
-         byte* ptr = (byte*)(Buffer + y * mStride + x1);
+         byte* ptr = (byte*)(Buffer + y * mStride + x1 - 1);
          System.Runtime.CompilerServices.Unsafe.InitBlock (ref *ptr, (byte)gray, (uint)(x2 - x1));
       };
       End ();

--- a/GrayBMP.cs
+++ b/GrayBMP.cs
@@ -105,6 +105,20 @@ class GrayBMP {
       End ();
    }
 
+   /// <summary>Draw a horizontal line b/w two points (x0, y) and (x1, y)</summary>
+   /// <param name="gray">Color of the line</param>
+   public void DrawHorizontalLine (int x1, int x2, int y, int gray) {
+      Begin (); Check (x1, y); Check (x2, y);
+      Dirty (x1, y); Dirty (x2, y);
+      if (x2 < x1) (x2, x1) = (x1, x2);
+      byte bGray = (byte)gray;
+      unsafe {
+         byte* ptr = (byte*)(Buffer + y * mStride + x1);
+         System.Runtime.CompilerServices.Unsafe.InitBlock (ref *ptr, (byte)gray, (uint)(x2 - x1));
+      };
+      End ();
+   }
+
    /// <summary>Call End after finishing the update of the bitmap</summary>
    public void End () {
       if (--mcLocks == 0) {

--- a/PolyFill.cs
+++ b/PolyFill.cs
@@ -68,11 +68,14 @@ namespace GrayBMP {
       static double ScanLnIntersection (Point2 p1, Point2 p2, double sY) {
          double X1 = p1.X, Y1 = p1.Y, X2 = p2.X, Y2 = p2.Y;
          double dY = Y2 - Y1, dX = X2 - X1;
+         // If line is above or below the scan line no intersection is possible
          if (Y1 < sY && Y2 < sY || Y1 > sY && Y2 > sY) return double.NaN;
+         // No intersection if the line is parallel to scan line
          if (dY == 0) return double.NaN;
          sY += 0.5;
          double xS = (dX != 0 ? (sY - Y1) * dX / dY : 0) + X1;
          if (dY < 0) (Y1, Y2) = (Y2, Y1);
+         // If the point of intersection is above or below the line segment -> not an intersection
          if (sY < Y1 || sY > Y2) return double.NaN;
          return xS;
       }

--- a/PolyFill.cs
+++ b/PolyFill.cs
@@ -8,6 +8,9 @@ using System.Windows.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using System.IO;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Collections;
 
 namespace GrayBMP {
 
@@ -27,6 +30,37 @@ namespace GrayBMP {
          }
       }
 
+      public void FillM (GrayBMP bmp, int color) {
+         ConcurrentQueue<int> Queue = new (Enumerable.Range (0, bmp.Height));
+         bmp.Begin ();
+         int threads = Environment.ProcessorCount; ;
+         var mCEV = new CountdownEvent (threads);
+         for (int i = 0; i < threads; i++)
+            new Thread (FillS).Start ();
+         mCEV.Wait ();
+         bmp.Dirty (0, 0, bmp.Width - 1, bmp.Height - 1);
+         bmp.End ();
+
+         void FillS () {
+            while (Queue.TryDequeue (out int y)) {
+               var iPts = mLines.Select (a => ScanLnIntersection (a.Item1, a.Item2, y)).Where (a => a is not double.NaN).OrderBy (a => a).ToList ();
+               if (iPts.Count > 0 && iPts.Count % 2 == 0)
+                  for (int j = 0; j < iPts.Count; j += 2)
+                     DrawHorizontalLine ((int)iPts[j], (int)iPts[j + 1], y, 255);
+         
+            }mCEV.Signal ();
+         }
+
+         void DrawHorizontalLine (int x1, int x2, int y, int gray) {
+            if (x2 < x1) (x2, x1) = (x1, x2);
+            byte bGray = (byte)gray;
+            unsafe {
+               byte* ptr = (byte*)(bmp.Buffer + y * bmp.Stride + x1);
+               System.Runtime.CompilerServices.Unsafe.InitBlock (ref *ptr, (byte)gray, (uint)(x2 - x1));
+            };
+         }
+      }
+
       /// <summary> Find intersection point of a given line segment with a scan line at height lY </summary>
       /// <param name="p1">Start point of line</param>
       /// <param name="p2">End point of line</param>
@@ -34,6 +68,7 @@ namespace GrayBMP {
       static double ScanLnIntersection (Point2 p1, Point2 p2, double sY) {
          double X1 = p1.X, Y1 = p1.Y, X2 = p2.X, Y2 = p2.Y;
          double dY = Y2 - Y1, dX = X2 - X1;
+         if (Y1 < sY && Y2 < sY || Y1 > sY && Y2 > sY) return double.NaN;
          if (dY == 0) return double.NaN;
          sY += 0.5;
          double xS = (dX != 0 ? (sY - Y1) * dX / dY : 0) + X1;

--- a/PolyFill.cs
+++ b/PolyFill.cs
@@ -12,38 +12,34 @@ using System.IO;
 namespace GrayBMP {
 
    class PolyFill {
-      public void AddLine (int x0, int y0, int x1, int y1) => mLines.Add (new (new (x0, y0), new (x1, y1)));
+      public void AddLine (int x0, int y0, int x1, int y1) {
+         if ((x0, y0) == (x1, y1)) return;
+         mLines.Add (new (new (x0, y0), new (x1, y1))); 
+      }
 
       /// <summary> Draw all mLines to the bmp and fill all closed polylines with the given color </summary>
       public void Fill (GrayBMP bmp, int color) {
          for (int i = 0; i < bmp.Height; i++) {
-            var lPts = mLines.Select (a => ScanLnIntersection (a.Item1, a.Item2, bmp.Width, i)).Where (a => a.X is not double.NaN).ToList ();
-            if (lPts.Count > 0 && lPts.Count % 2 == 0)
-               for (int j = 0; j < lPts.Count; j += 2)
-                  bmp.DrawHorizontalLine ((int)lPts[j].X, (int)lPts[j + 1].X, i, 255);
+            var iPts = mLines.Select (a => ScanLnIntersection (a.Item1, a.Item2, i)).Where (a => a is not double.NaN).OrderBy (a => a).ToList ();
+            if (iPts.Count > 0 && iPts.Count % 2 == 0)
+               for (int j = 0; j < iPts.Count; j += 2)
+                  bmp.DrawHorizontalLine ((int)iPts[j], (int)iPts[j + 1], i, 255);
          }
       }
 
       /// <summary> Find intersection point of a given line segment with a scan line at height lY </summary>
       /// <param name="p1">Start point of line</param>
       /// <param name="p2">End point of line</param>
-      /// <param name="width">Width of the screen</param>
-      /// <param name="lY">Height of the scan line</param>
-      static Point2 ScanLnIntersection (Point2 p1, Point2 p2, double width, double lY) {
-         lY += 0.5;
-         if (p1.Y < lY && p2.Y < lY || p1.Y > lY && p2.Y > lY) return new (double.NaN, double.NaN);
+      /// <param name="sY">Height of the scan line</param>
+      static double ScanLnIntersection (Point2 p1, Point2 p2, double sY) {
          double X1 = p1.X, Y1 = p1.Y, X2 = p2.X, Y2 = p2.Y;
          double dY = Y2 - Y1, dX = X2 - X1;
-         if (Math.Abs (dY) < DELTA && Math.Abs (dX) < DELTA) return new (double.NaN, double.NaN);
-         double c1 = X1 * dY - Y1 * dX;
-         double b2 = width;
-         double c2 = -lY * width;
-         double d = -dY * b2;
-         Point2 pInt = new ((dX * c2 - b2 * c1) / d, c2 * dY / d);
-         if (dX < 0) (X1, X2) = (X2, X1);
+         if (dY == 0) return double.NaN;
+         sY += 0.5;
+         double xS = (dX != 0 ? (sY - Y1) * dX / dY : 0) + X1;
          if (dY < 0) (Y1, Y2) = (Y2, Y1);
-         if (pInt.X >= X1 && pInt.X <= X2 && pInt.Y >= Y1 && pInt.Y <= Y2) return pInt;
-         return new (double.NaN, double.NaN);
+         if (sY < Y1 || sY > Y2) return double.NaN;
+         return xS;
       }
 
       struct Point2 {

--- a/PolyFill.cs
+++ b/PolyFill.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.IO;
+
+namespace GrayBMP {
+
+   class PolyFill {
+      public void AddLine (int x0, int y0, int x1, int y1) => mLines.Add (new (new (x0, y0), new (x1, y1)));
+
+      /// <summary> Draw all mLines to the bmp and fill all closed polylines with the given color </summary>
+      public void Fill (GrayBMP bmp, int color) {
+         for (int i = 0; i < bmp.Height; i++) {
+            var lPts = mLines.Select (a => ScanLnIntersection (a.Item1, a.Item2, bmp.Width, i)).Where (a => a.X is not double.NaN).ToList ();
+            if (lPts.Count > 0 && lPts.Count % 2 == 0)
+               for (int j = 0; j < lPts.Count; j += 2)
+                  bmp.DrawHorizontalLine ((int)lPts[j].X, (int)lPts[j + 1].X, i, 255);
+         }
+      }
+
+      /// <summary> Find intersection point of a given line segment with a scan line at height lY </summary>
+      /// <param name="p1">Start point of line</param>
+      /// <param name="p2">End point of line</param>
+      /// <param name="width">Width of the screen</param>
+      /// <param name="lY">Height of the scan line</param>
+      static Point2 ScanLnIntersection (Point2 p1, Point2 p2, double width, double lY) {
+         lY += 0.5;
+         if (p1.Y < lY && p2.Y < lY || p1.Y > lY && p2.Y > lY) return new (double.NaN, double.NaN);
+         double X1 = p1.X, Y1 = p1.Y, X2 = p2.X, Y2 = p2.Y;
+         double dY = Y2 - Y1, dX = X2 - X1;
+         if (Math.Abs (dY) < DELTA && Math.Abs (dX) < DELTA) return new (double.NaN, double.NaN);
+         double c1 = X1 * dY - Y1 * dX;
+         double b2 = width;
+         double c2 = -lY * width;
+         double d = -dY * b2;
+         Point2 pInt = new ((dX * c2 - b2 * c1) / d, c2 * dY / d);
+         if (dX < 0) (X1, X2) = (X2, X1);
+         if (dY < 0) (Y1, Y2) = (Y2, Y1);
+         if (pInt.X >= X1 && pInt.X <= X2 && pInt.Y >= Y1 && pInt.Y <= Y2) return pInt;
+         return new (double.NaN, double.NaN);
+      }
+
+      struct Point2 {
+         public Point2 (double x, double y) { X = x; Y = y; }
+         public double X, Y;
+      }
+      List<(Point2, Point2)> mLines = new ();
+      const double DELTA = 0.1;
+   }
+}


### PR DESCRIPTION
Created a pull request to tarydon/Graphics23 earlier by mistake.
Here are the review comments and corresponding replies.

1. _When you draw a line from (10,5) to (20,5) I would expect that line to be 11 pixels long (including both 10,5 and 20,5). Your code will make a line that is 1 pixel too short._
   
     Reduced start ptr by 1 (x1 - 1)
2. _Are you sure the lPts will be sorted in ascending order of X? Otherwise, the next line of code will not really be picking 'adjacent intersections'._ 
     
     Sorting intersection pts now
3. _Faster if you just return a double from here - the Y coordinate is not really important - it is always equal to lY_
    
     Returning only the 'X' value of the intersection point from 'ScanLnIntersection' method
4. _Don't start variable names with lowercase L - it looks too similar to the numeral 1 and is confusing._ 
    
      Renamed variables
5. _You can simplify things later on by not even adding horizontal lines into the mLines list. That will also ensure you have no 'empty' lines (x0,y0) == (x1,y1)_
   
      Added a check for empty lines in 'AddLine' method